### PR TITLE
Add `YmVoice.toFile` method

### DIFF
--- a/src/opl-voice.ts
+++ b/src/opl-voice.ts
@@ -253,4 +253,7 @@ export class OPLVoice extends YMVoice {
 `;
   }
 
+  toFile(): string | Uint8Array {
+    return "";
+  }
 }

--- a/src/opll-voice.ts
+++ b/src/opll-voice.ts
@@ -254,6 +254,10 @@ export class OPLLVoice extends YMVoice {
   ${[s[1].ar, s[1].dr, s[1].sl, s[1].rr, s[1].kl, s[1].ml, s[1].am, s[1].pm, s[1].eg, s[1].kr, s[1].ws].map(pad2).join(',')} }
 `;
   }
+
+  toFile(): string | Uint8Array {
+    return "";
+  }
 }
 
 export const OPLLVoiceMap = _OPLL_ROM_PATCHES.map((e) => OPLLVoice.decode(e));

--- a/src/opn-voice.ts
+++ b/src/opn-voice.ts
@@ -2,6 +2,7 @@ import { OPMSlotParam, OPMVoice } from "./opm-voice";
 import { OPLSlotParam, OPLVoice } from "./opl-voice";
 import { YMVoice } from "./ym-voice";
 
+const pad3 = (e: any) => ("   " + e).slice(-3);
 export class OPNSlotParam {
   __type: "OPNSlotParam" = "OPNSlotParam";
   dt: number;
@@ -373,7 +374,6 @@ ${data.slice(20, 24).map(pad0x3).join(',')} ; SL/RR
 ${data.slice(24).map(pad0x3).join(',')}                ; FB/AL
     `
     } if (type === "mucom88") {
-      const pad3 = (e: any) => ("   " + e).slice(-3);
       return `; OPN voice for MUCOM88
   @0
 ${[this.fb, this.con].map(pad3).join(',')}
@@ -393,6 +393,36 @@ ${[s[3].ar, s[3].dr, s[3].sr, s[3].rr, s[3].sl, s[3].tl, s[3].ks, s[3].ml, s[3].
   ${[s[2].ar, s[2].dr, s[2].sr, s[2].rr, s[2].sl, s[2].tl, s[2].ks, s[2].ml, s[2].dt, s[2].am].map(pad03).join(' ')}
   ${[s[3].ar, s[3].dr, s[3].sr, s[3].rr, s[3].sl, s[3].tl, s[3].ks, s[3].ml, s[3].dt, s[3].am].map(pad03).join(' ')}
 `;
+    }
+  }
+
+  toFile(type: "dmp" | "tfi" | "vgi" = "tfi"): string | Uint8Array {
+    const s = this.slots;
+    const convertDetune = (detune: number) => detune > 3 ? 7 - detune : detune;
+    if (type === "dmp") {
+      return new Uint8Array([
+        ...[0x0a, 1, this.pms, this.fb, this.con, this.ams],
+        ...[s[0].ml, s[0].tl, s[0].ar, s[0].dr, s[0].sl, s[0].rr, s[0].am, s[0].ks, s[0].dt, s[0].sr, 0],
+        ...[s[1].ml, s[1].tl, s[1].ar, s[1].dr, s[1].sl, s[1].rr, s[1].am, s[1].ks, s[1].dt, s[1].sr, 0],
+        ...[s[2].ml, s[2].tl, s[2].ar, s[2].dr, s[2].sl, s[2].rr, s[2].am, s[2].ks, s[2].dt, s[2].sr, 0],
+        ...[s[3].ml, s[3].tl, s[3].ar, s[3].dr, s[3].sl, s[3].rr, s[3].am, s[3].ks, s[3].dt, s[3].sr, 0],
+      ]);
+    } else if (type === "vgi") {
+      return new Uint8Array([
+        ...[this.con, this.fb, this.pms | this.ams << 4],
+        ...[s[0].ml, convertDetune(s[0].dt), s[0].tl, s[0].ks, s[0].ar, s[0].dr, s[0].sr, s[0].rr, s[0].sl, 0],
+        ...[s[1].ml, convertDetune(s[1].dt), s[1].tl, s[1].ks, s[1].ar, s[1].dr, s[1].sr, s[1].rr, s[1].sl, 0],
+        ...[s[2].ml, convertDetune(s[2].dt), s[2].tl, s[2].ks, s[2].ar, s[2].dr, s[2].sr, s[2].rr, s[2].sl, 0],
+        ...[s[3].ml, convertDetune(s[3].dt), s[3].tl, s[3].ks, s[3].ar, s[3].dr, s[3].sr, s[3].rr, s[3].sl, 0],
+      ]);
+    } else {
+      return new Uint8Array([
+        ...[this.con, this.fb],
+        ...[s[0].ml, convertDetune(s[0].dt), s[0].tl, s[0].ks, s[0].ar, s[0].dr, s[0].sr, s[0].rr, s[0].sl, 0],
+        ...[s[1].ml, convertDetune(s[1].dt), s[1].tl, s[1].ks, s[1].ar, s[1].dr, s[1].sr, s[1].rr, s[1].sl, 0],
+        ...[s[2].ml, convertDetune(s[2].dt), s[2].tl, s[2].ks, s[2].ar, s[2].dr, s[2].sr, s[2].rr, s[2].sl, 0],
+        ...[s[3].ml, convertDetune(s[3].dt), s[3].tl, s[3].ks, s[3].ar, s[3].dr, s[3].sr, s[3].rr, s[3].sl, 0],
+      ]);
     }
   }
 }

--- a/src/ym-voice.ts
+++ b/src/ym-voice.ts
@@ -6,5 +6,6 @@ export abstract class YMVoice {
     return this.encode().map(e => ("0" + e.toString(16)).slice(-2)).join("");
   }
   abstract toMML(type?: string | null): string;
+  abstract toFile(type?: string | null, parameters?: {[key: string]: any}): string | Uint8Array;
 }
 


### PR DESCRIPTION
For consistency, I've added methods for OPL and OPLL, but I am not aware of any standard file formats for OPL(L) voices.

A few open questions:
1. Most instrument file types are binary, but OPM files are plaintext. I've had `toFile` return a union type, with the idea that the consuming could would have to check the return type to determine whether to write it as plaintext or a binary file. Alternatives I considered are having separate methods for this division, or stuffing OPM in `toMML` (but I think that's probably incorrect).
2. I wasn't sure what to do with the the instrument index for `'opm'` conversion. Options: leave out the header (consuming code will need to insert the instrument number & title), or have optional parameters argument in `toFile` (e.g. `toFile(type, parameters?: { [key: string]: any })`, where parameters are file type-specific), or just hardcode index 0 and let consuming application fix it.